### PR TITLE
Add support for kured

### DIFF
--- a/update_engine.go
+++ b/update_engine.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -28,6 +29,9 @@ const (
 	intervalFuzz     = 10 * time.Minute
 	// This file should always exist on Flatcar
 	osReleasePath = "/etc/os-release"
+	// Flag file location for kured:
+	// https://github.com/flatcar-linux/update_engine/commit/93f6cdddd46e9fba6c336c1db3baa6c89d85979b
+	kuredReleasePath = "/run/reboot-required"
 )
 
 // dbusConn is an interface for all the methods of *dbus.Conn that the
@@ -143,6 +147,9 @@ func (ue *updateEngine) checkForUpdate() error {
 			return err
 		}
 
+		if err := touchFile(kuredReleasePath); err != nil {
+			return err
+		}
 		log.Printf("Updated status: %s\n", ue.status)
 
 		return nil
@@ -225,6 +232,24 @@ func getValue(match, body string) (string, error) {
 	}
 
 	return "", fmt.Errorf("couldn't get value for %s", match)
+}
+
+func touchFile(fileName string) error {
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		file, err := os.Create(fileName)
+		defer file.Close()
+		if err != nil {
+			return err
+		}
+	} else {
+		currentTime := time.Now().Local()
+		err = os.Chtimes(fileName, currentTime, currentTime)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // fuzzDuration adds a random jitter to a given duration. It's adapted from the

--- a/update_engine.go
+++ b/update_engine.go
@@ -29,6 +29,9 @@ const (
 	intervalFuzz     = 10 * time.Minute
 	// This file should always exist on Flatcar
 	osReleasePath = "/etc/os-release"
+)
+
+var (
 	// Flag file location for kured:
 	// https://github.com/flatcar-linux/update_engine/commit/93f6cdddd46e9fba6c336c1db3baa6c89d85979b
 	kuredReleasePath = "/run/reboot-required"

--- a/update_engine_test.go
+++ b/update_engine_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -56,6 +58,9 @@ func TestUpdateEngineCheckForUpdate(t *testing.T) {
 
 	d := &dbusConnRecorder{}
 
+	// Test path for the kured release loaction
+	kuredReleasePath = fmt.Sprintf("%s/reboot-required", t.TempDir())
+
 	ue := updateEngine{
 		conn:       d,
 		status:     s,
@@ -84,6 +89,10 @@ func TestUpdateEngineCheckForUpdate(t *testing.T) {
 	assert.Equal(t, d.Values[3], "2605.12.0")
 	assert.Equal(t, ue.status.currentOperation, updateStatusUpdatedNeedReboot)
 	assert.Equal(t, ue.status.newVersion, "2605.12.0")
+	// Check that we have the flag file for kured
+	if _, err := os.Stat(kuredReleasePath); os.IsNotExist(err) {
+		t.Fatal("Missing release flag file for kured")
+	}
 }
 
 func TestUpdateEngineResetStatus(t *testing.T) {


### PR DESCRIPTION
Following flatcar update_engine commit:
https://github.com/flatcar-linux/update_engine/commit/93f6cdddd46e9fba6c336c1db3baa6c89d85979b
This ensures that we `touch /run/reboot-required` file every time a node reports
ready for a reboot.